### PR TITLE
Fix manual seed crypto for CryptNCCH. (Possibly related to issue 20)

### DIFF
--- a/source/decryptor/game.c
+++ b/source/decryptor/game.c
@@ -487,7 +487,7 @@ u32 CryptNcch(const char* filename, u32 offset, u32 size, u64 seedId, u8* encryp
     }
     
     // select correct title ID for seed crypto
-    if (seedId == 0) seedId = ncch->partitionId;
+    if (seedId == 0) seedId = ncch->programId;
     
     // copy over encryption parameters (if applicable)
     if (encrypt_flags) {


### PR DESCRIPTION
Some examples:
・The manual of programID 0004000000117100 lists partitionID 0005000000117100
・The manual of programID 0004000000167D00 lists partitionID 000400000FF3FF00
In both cases the manual's cryptofixing will fail when using an NCCH. A seed matching the partitionID is not found in the file used by seedconv.exe.