### PR TITLE
add ability to use FONT=LINUX to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,10 @@ ifneq ($(strip $(THEME)),)
 CFLAGS	+=	-DUSE_THEME=\"\/$(THEME)\"
 endif
 
+ifeq ($(FONT),LINUX)
+CFLAGS	+=	-DUSE_LINUX_FONT
+endif
+
 CXXFLAGS	:= $(CFLAGS) -fno-rtti -fno-exceptions
 
 ASFLAGS	:=	-g $(ARCH) -DEXEC_$(EXEC_METHOD)


### PR DESCRIPTION
I noticed you added an extra font, but it has to be enabled by uncommenting "`#define USE_LINUX_FONT`" in `font.h`. I do like it, but I'd like to be able to enable it when using make, so I added this to the Makefile.

tested this ("`make FONT=LINUX`") and it works, though you might have a better implementation.