### PR TITLE
Fix H&S injection in iQue/Taiwan O3DS

### DIFF
--- a/source/decryptor/nandfat.h
+++ b/source/decryptor/nandfat.h
@@ -33,8 +33,8 @@ typedef struct {
 
 u32 SeekFileInNand(u32* offset, u32* size, const char* path, PartitionInfo* partition);
 u32 DebugSeekFileInNand(u32* offset, u32* size, const char* filename, const char* path, PartitionInfo* partition);
-u32 SeekTitleInNandDb(u32* tid_low, u32* tmd_id, TitleListInfo* title_info);
-u32 DebugSeekTitleInNand(u32* offset_tmd, u32* size_tmd, u32* offset_app, u32* size_app, TitleListInfo* title_info, u32 max_cnt);
+u32 SeekTitleInNandDb(u32* tid_low, u32* tmd_id, TitleListInfo* title_info, u32* index);
+u32 DebugSeekTitleInNand(u32* offset_tmd, u32* size_tmd, u32* offset_app, u32* size_app, TitleListInfo* title_info, u32 max_cnt, u32 min_size);
 
 // --> FEATURE FUNCTIONS <--
 u32 DumpFile(u32 param);


### PR DESCRIPTION
We have tested H&S injections on iQue/Taiwan O3DS and found something terrible:
They all have title 0004001000026300(iQue O3DS H&S) and 0004001000028300 (Taiwan O3DS H&S) installed in nand and the one different from console language is just a tiny app with size ~15KiB, which seems to be a fake one used to jump to main H&S app.
This commit changes it to search up for all available H&S apps where are >=64KiB to fix the issue.