### PR TITLE
Fix TWL dump filenames; add versions to CTR dump filenames and some other fixes.

### DIFF
--- a/source/decryptor/game.c
+++ b/source/decryptor/game.c
@@ -2169,8 +2169,10 @@ u32 DumpTwlGameCart(u32 param)
     }
 
     Debug("");
-    snprintf(filename, 64, "/%s%s%s%02X.nds", GetGameDir() ? GetGameDir() : "", GetGameDir() ? "/" : "",
-        (char*) &buff[0x0C], buff[0x1E]);
+    snprintf(filename, 64, "/%s%s%.6s_%02X.nds",
+		GetGameDir() ? GetGameDir() : "",
+		GetGameDir() ? "/" : "",
+		(const char*)&buff[0x0C], buff[0x1E]);
 
     if (!DebugFileCreate(filename, true))
         return 1;

--- a/source/decryptor/game.c
+++ b/source/decryptor/game.c
@@ -2153,12 +2153,20 @@ u32 DumpTwlGameCart(u32 param)
         return 1;
     }
 
+    // Unitcode (00h=NDS, 02h=NDS+DSi, 03h=DSi) (bit1=DSi)
+    isDSi = (buff[0x12] != 0x00);
     Debug("Product name: %.12s", (char*) &buff[0x00]);
     Debug("Product ID: %.6s", (char*) &buff[0x0C]);
     Debug("Product version: %02u", buff[0x1E]);
 
     cart_size = (128 * 1024) << buff[0x14];
-    data_size = *((u32*)&buff[0x80]);
+    if (isDSi) {
+        // NTR used data size field does not include TWL-specific data.
+        // Use the TWL field.
+        data_size = *((u32*)&buff[0x210]);
+    } else {
+        data_size = *((u32*)&buff[0x80]);
+    }
     dump_size = (param & CD_TRIM) ? data_size : cart_size;
     Debug("Cartridge data size: %lluMB", cart_size / 0x100000);
     Debug("Cartridge used size: %lluMB", data_size / 0x100000);
@@ -2187,10 +2195,7 @@ u32 DumpTwlGameCart(u32 param)
         return 1;
     }
     
-    // Unitcode (00h=NDS, 02h=NDS+DSi, 03h=DSi) (bit1=DSi)
-    if (buff[0x12] != 0x00) {
-        isDSi = 1;
-        
+    if (isDSi) {
         // initialize cartridge
         Cart_Init();
         //Cart_GetID();

--- a/source/decryptor/game.c
+++ b/source/decryptor/game.c
@@ -1954,7 +1954,7 @@ u32 DumpCtrGameCart(u32 param)
     
     // output some info
     Debug("Product ID: %.16s", ncch->productcode);
-    Debug("Product version: %02u", ncsd->version);
+    Debug("Product version: %02u", ((u8*)ncsd)[0x312]);
     Debug("Cartridge data size: %lluMB", cart_size / 0x100000);
     Debug("Cartridge used size: %lluMB", data_size / 0x100000);
     if (data_size > cart_size) {
@@ -1999,7 +1999,7 @@ u32 DumpCtrGameCart(u32 param)
         GetGameDir() ? GetGameDir() : "",
         GetGameDir() ? "/" : "",
         ncch->productcode,
-        ncsd->version,
+        ((u8*)ncsd)[0x312],	// version
         (param & CD_DECRYPT) ? "-dec" : "",
         (param & CD_MAKECIA) ? "cia" : "3ds");
     if (!FileCreate(filename, true)) {

--- a/source/decryptor/game.c
+++ b/source/decryptor/game.c
@@ -1954,6 +1954,7 @@ u32 DumpCtrGameCart(u32 param)
     
     // output some info
     Debug("Product ID: %.16s", ncch->productcode);
+    Debug("Product version: %02X", ncsd->version);
     Debug("Cartridge data size: %lluMB", cart_size / 0x100000);
     Debug("Cartridge used size: %lluMB", data_size / 0x100000);
     if (data_size > cart_size) {
@@ -1994,8 +1995,13 @@ u32 DumpCtrGameCart(u32 param)
     
     // create file, write CIA / NCSD header
     Debug("");
-    snprintf(filename, 64, "/%s%s%.16s%s.%s", GetGameDir() ? GetGameDir() : "", GetGameDir() ? "/" : "", 
-        ncch->productcode, (param & CD_DECRYPT) ? "-dec" : "", (param & CD_MAKECIA) ? "cia" : "3ds");
+    snprintf(filename, 64, "/%s%s%.16s_%02X%s.%s",
+        GetGameDir() ? GetGameDir() : "",
+        GetGameDir() ? "/" : "",
+        ncch->productcode,
+        ncsd->version,
+        (param & CD_DECRYPT) ? "-dec" : "",
+        (param & CD_MAKECIA) ? "cia" : "3ds");
     if (!FileCreate(filename, true)) {
         Debug("Could not create output file on SD");
         return 1;
@@ -2170,9 +2176,9 @@ u32 DumpTwlGameCart(u32 param)
 
     Debug("");
     snprintf(filename, 64, "/%s%s%.6s_%02X.nds",
-		GetGameDir() ? GetGameDir() : "",
-		GetGameDir() ? "/" : "",
-		(const char*)&buff[0x0C], buff[0x1E]);
+        GetGameDir() ? GetGameDir() : "",
+        GetGameDir() ? "/" : "",
+        (const char*)&buff[0x0C], buff[0x1E]);
 
     if (!DebugFileCreate(filename, true))
         return 1;

--- a/source/decryptor/game.c
+++ b/source/decryptor/game.c
@@ -1954,7 +1954,7 @@ u32 DumpCtrGameCart(u32 param)
     
     // output some info
     Debug("Product ID: %.16s", ncch->productcode);
-    Debug("Product version: %02X", ncsd->version);
+    Debug("Product version: %02u", ncsd->version);
     Debug("Cartridge data size: %lluMB", cart_size / 0x100000);
     Debug("Cartridge used size: %lluMB", data_size / 0x100000);
     if (data_size > cart_size) {
@@ -1995,7 +1995,7 @@ u32 DumpCtrGameCart(u32 param)
     
     // create file, write CIA / NCSD header
     Debug("");
-    snprintf(filename, 64, "/%s%s%.16s_%02X%s.%s",
+    snprintf(filename, 64, "/%s%s%.16s_%02u%s.%s",
         GetGameDir() ? GetGameDir() : "",
         GetGameDir() ? "/" : "",
         ncch->productcode,
@@ -2155,7 +2155,7 @@ u32 DumpTwlGameCart(u32 param)
 
     Debug("Product name: %.12s", (char*) &buff[0x00]);
     Debug("Product ID: %.6s", (char*) &buff[0x0C]);
-    Debug("Product version: %02X", buff[0x1E]);
+    Debug("Product version: %02u", buff[0x1E]);
 
     cart_size = (128 * 1024) << buff[0x14];
     data_size = *((u32*)&buff[0x80]);
@@ -2175,7 +2175,7 @@ u32 DumpTwlGameCart(u32 param)
     }
 
     Debug("");
-    snprintf(filename, 64, "/%s%s%.6s_%02X.nds",
+    snprintf(filename, 64, "/%s%s%.6s_%02u.nds",
         GetGameDir() ? GetGameDir() : "",
         GetGameDir() ? "/" : "",
         (const char*)&buff[0x0C], buff[0x1E]);

--- a/source/decryptor/game.h
+++ b/source/decryptor/game.h
@@ -51,7 +51,7 @@ typedef struct {
 	u8  sector_zero_offset[0x4];
 	u8  partition_flags[8];
 	u8  partitionId_table[8][8];
-	u8  reserved[0x40];
+	u8  reserved[0x30];
 } __attribute__((packed, aligned(16))) NcsdHeader;
 
 typedef struct {

--- a/source/decryptor/game.h
+++ b/source/decryptor/game.h
@@ -51,12 +51,7 @@ typedef struct {
 	u8  sector_zero_offset[0x4];
 	u8  partition_flags[8];
 	u8  partitionId_table[8][8];
-	u8  reserved[0x30];
-
-	// 0x200
-	u8  reserved2[0x112];
-	// 0x312
-	u8  version;
+	u8  reserved[0x40];
 } __attribute__((packed, aligned(16))) NcsdHeader;
 
 typedef struct {

--- a/source/decryptor/game.h
+++ b/source/decryptor/game.h
@@ -51,7 +51,12 @@ typedef struct {
 	u8  sector_zero_offset[0x4];
 	u8  partition_flags[8];
 	u8  partitionId_table[8][8];
-	u8  reserved[0x40];
+	u8  reserved[0x30];
+
+	// 0x200
+	u8  reserved2[0x112];
+	// 0x312
+	u8  version;
 } __attribute__((packed, aligned(16))) NcsdHeader;
 
 typedef struct {


### PR DESCRIPTION
This PR fixes TWL dump filenames. When product version was added, a maximum field width wasn't specified, so the unitcode ends up getting appended, and that confuses some of the FatFS code.

Some additional changes:
* Append CTR versions to dump filenames. (Located at 0x312.)
* Use decimal for the version numbers instead of hexadecimal.
* For trimmed TWL dumps, use the TWL used size instead of the NTR used size, since the NTR used size doesn't include the TWL-specific area.