### PR TITLE
Fix to add compatibility for Boot9Strap 1.2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,7 +9,4 @@
 	path = CakesROP
 	url = https://github.com/mid-kid/CakesROP
 	ignore = dirty
-[submodule "firmtool"]
-	path = firmtool
-	url = https://github.com/TuxSH/firmtool.git
-	ignore = dirty
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -9,4 +9,7 @@
 	path = CakesROP
 	url = https://github.com/mid-kid/CakesROP
 	ignore = dirty
-
+[submodule "firmtool"]
+	path = firmtool
+	url = https://github.com/TuxSH/firmtool.git
+	ignore = dirty

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ ARCH	:=	-mthumb -mthumb-interwork -flto
 
 CFLAGS	:=	-g -Wall -Wextra -Wpedantic -Wno-main -O2\
 			-march=armv5te -mtune=arm946e-s -fomit-frame-pointer\
-			-ffast-math -std=c99\
+			-ffast-math -std=gnu11\
 			$(ARCH)
 
 CFLAGS	+=	$(INCLUDE) -DARM9 -D_GNU_SOURCE
@@ -130,7 +130,7 @@ binary: common
 	@make --no-print-directory -C $(BUILD) -f $(CURDIR)/Makefile
 
 firm: binary
-	@firmtool/firmtool build $(OUTPUT).firm -n 0x23F00000 -e 0 -D $(OUTPUT).bin -A 0x23F00000 -C NDMA -i
+	@firmtool build $(OUTPUT).firm -n 0x23F00000 -e 0 -D $(OUTPUT).elf -A 0x23F00000 -C NDMA -i
 
 gateway: binary
 	@cp resources/LauncherTemplate.dat $(OUTPUT_D)/Launcher.dat

--- a/source/draw.h
+++ b/source/draw.h
@@ -59,11 +59,13 @@
 #define DBG_N_CHARS_Y ((DBG_END_Y - DBG_START_Y) / DBG_STEP_Y)
 #define DBG_N_CHARS_X (((DBG_END_X - DBG_START_X) / FONT_WIDTH) + 1)
 
-#define TOP_SCREEN (u8*)(*(u32*)0x23FFFE00)
-#define BOT_SCREEN (u8*)(*(u32*)0x23FFFE08)
+#define TOP_SCREEN top_screen
+#define BOT_SCREEN bottom_screen
 
 #define ScreenWidth(x)       (((x) == (TOP_SCREEN) ? 400 : 320))
 #define IsCharPartOfWord(x)  (((x) >= 'a' && (x) <= 'z') || ((x) >= '0' && (x) <= '9') || ((x) >= 'A' && (x) <= 'Z'))
+
+extern u8 *top_screen, *bottom_screen;
 
 void ClearScreen(unsigned char *screen, int width, int color);
 void ClearScreenFull(bool clear_top, bool clear_bottom);

--- a/source/gamecart/protocol.c
+++ b/source/gamecart/protocol.c
@@ -28,7 +28,6 @@
 #define REG_AESKEYXFIFO (*(vu32*)0x10009104)
 #define REG_AESKEYYFIFO (*(vu32*)0x10009108)
 
-extern u8* bottomScreen;
 
 u32 CartID = 0xFFFFFFFFu;
 u32 CartType = 0;

--- a/source/main.c
+++ b/source/main.c
@@ -98,8 +98,9 @@ u32 InitializeD9(MenuInfo *menu)
     return errorlevel;
 }
 
+u8 *top_screen, *bottom_screen;
 
-int main()
+int main(int argc, char** argv)
 {
     MenuInfo menu[] =
     {
@@ -452,6 +453,17 @@ int main()
             NULL, 0, { { 0 } } // empty menu to signal end
         }
     };
+   // Fetch the framebuffer addresses
+    if(argc >= 2) {
+        // newer entrypoints
+        u8 **fb = (u8 **)(void *)argv[1];
+        top_screen = fb[0];
+        bottom_screen = fb[2];
+    } else {
+        // outdated entrypoints
+        top_screen = (u8*)(*(u32*)0x23FFFE00);
+        bottom_screen = (u8*)(*(u32*)0x23FFFE08);
+    }
 
     u32 menu_exit = MENU_EXIT_REBOOT;
 

--- a/source/start.s
+++ b/source/start.s
@@ -65,6 +65,14 @@ _start_gw:
     stmia r0, {r1,r2,r3}
     @ framebuffers properly set
 
+    ldr r3, =0xFFFF0830         @ flush (clean & invalidate) entire dcache b9 func
+    blx r3
+ 
+    mov r3, #0
+    mcr p15, 0, r3, c7, c5, 0   @ invalidate I-cache
+ 
+    mov r2, #0
+
     ldr r3, .entry
     bx r3
 
@@ -74,8 +82,18 @@ _start_gw:
 .entry:   .word 0x23F00000
 
 _skip_gw:
+    mov r9, r0      @ argc
+    mov r10, r1     @ argv
+ 
+    ldr r4, =0xBEEF
+    lsl r2, #16
+    lsr r2, #16
+    cmp r2, r4      @ magic word
+    movne r9, #0
+ 
     @ Disable caches / mpu
     mrc p15, 0, r4, c1, c0, 0  @ read control register
+    bic r4, #(1<<16)           @ - dtcm disable (mandated by the docs, before you change the dtcm's address)
     bic r4, #(1<<12)           @ - instruction cache disable
     bic r4, #(1<<2)            @ - data cache disable
     bic r4, #(1<<0)            @ - mpu disable
@@ -91,10 +109,10 @@ _skip_gw:
         strlt r2, [r0], #4
         blt .bss_clr
 
-    @ Flush caches
+    @ Invalidate caches
     mov r5, #0
-    mcr p15, 0, r5, c7, c5, 0  @ flush I-cache
-    mcr p15, 0, r5, c7, c6, 0  @ flush D-cache
+    mcr p15, 0, r5, c7, c5, 0  @ invalidate I-cache
+    mcr p15, 0, r5, c7, c6, 0  @ invalidate D-cache
     mcr p15, 0, r5, c7, c10, 4 @ drain write buffer
 
     @ Give read/write access to all the memory regions
@@ -144,7 +162,9 @@ _skip_gw:
 
     mov sp, #0x27000000
 
-    blx main
-    b _start
+
+    mov r0, r9
+    mov r1, r10
+    b main
 
 .pool


### PR DESCRIPTION
I made the changes made in godmode9 commits  d8d2901ec1b125fdb36e2c728cfa8e84f9bc13f3 and 540daed73a7672fbdfe061675bba8f3c6920c573 to Decrypt9 to add compatibility to B9S 1.2. .
Tested it on Boot9strap 1.2 and got it to work successfully, can't confirm for 1.1